### PR TITLE
エラー文の冗長な部分を削除

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,11 @@ func main() {
 				if i == -1 {
 					panic(body_str)
 				}
-				panic(body_str[i:])
+				j := strings.Index(body_str, "No pages of output.")
+				if j == -1 {
+					panic(body_str[i:])
+				}
+				panic(body_str[i:j])
 			}
 			panic(err)
 		}
@@ -120,7 +124,11 @@ func main() {
 		if i == -1 {
 			panic(body_str)
 		}
-		panic(body_str[i:])
+		j := strings.Index(body_str, "No pages of output.")
+		if j == -1 {
+			panic(body_str[i:])
+		}
+		panic(body_str[i:j])
 	}
 	jpeg_data := bytes.NewBuffer([]byte{})
 	tar_reader := tar.NewReader(tar_dl_data)


### PR DESCRIPTION
LaTeX のエラーの
No pages of output.
以下が不必要だと思ったので切るようにしました